### PR TITLE
Tracing Hibernate service calls

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/SFAgentUtil.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/SFAgentUtil.java
@@ -24,19 +24,22 @@
  */
 package co.elastic.apm.agent.bci;
 
-import org.apache.commons.codec.binary.Base64;
-import org.json.JSONObject;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.nio.file.FileSystems;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
+
 import javax.crypto.Cipher;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
+
+import org.apache.commons.codec.binary.Base64;
+import org.json.JSONObject;
 
 public class SFAgentUtil {
   private static byte[] key;
@@ -44,7 +47,7 @@ public class SFAgentUtil {
   public SFConfigInfo parseSFAgentYamlFile() {
     FileReader fr = null;
     try {
-      File file = new File("/opt/sfagent/config.yaml");
+      File file = new File(setSFtraceConfig());
       fr = new FileReader(file);
       BufferedReader br = new BufferedReader(fr);
       SFConfigInfo cfgInfo = new SFConfigInfo();
@@ -87,6 +90,20 @@ public class SFAgentUtil {
       
       } catch (Exception exception) {}
     } 
+  }
+  
+  public String setSFtraceConfig() {
+	  
+	  String sfConfFileName = "config.yaml";
+	  String s = FileSystems.getDefault().getSeparator();
+	  String confProp = System.getProperty("sftrace.config");
+	  String confEnv = System.getenv("SFTRACE_CONFIG");
+	  String sfConf = confEnv != null ? confEnv :
+		  					confProp != null ? confProp:
+		  						"/opt/sfagent"; //Fallback to Linux path
+	  
+	  return sfConf+s+sfConfFileName;
+			  			
   }
   
   public void setAgentInputParams() {

--- a/apm-agent-plugins/apm-hibernate-plugin/pom.xml
+++ b/apm-agent-plugins/apm-hibernate-plugin/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<project
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
+	xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>co.elastic.apm</groupId>
+		<artifactId>apm-agent-plugins</artifactId>
+		<version>1.18.0</version>
+	</parent>
+	<artifactId>apm-hibernate-plugin</artifactId>
+	<name>${project.groupId}:${project.artifactId}</name>
+
+	<properties>
+		<apm-agent-parent.base.dir>${project.basedir}/../..</apm-agent-parent.base.dir>
+		<testcontainers-version>1.12.0</testcontainers-version>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-core</artifactId>
+			<version>5.5.4.Final</version>
+			<scope>provided</scope>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/apm-agent-plugins/apm-hibernate-plugin/src/main/java/co/elastic/apm/agent/hibernate/HibernateInstrumentation.java
+++ b/apm-agent-plugins/apm-hibernate-plugin/src/main/java/co/elastic/apm/agent/hibernate/HibernateInstrumentation.java
@@ -1,0 +1,43 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2020 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
+package co.elastic.apm.agent.hibernate;
+
+import co.elastic.apm.agent.bci.TracerAwareInstrumentation;
+import co.elastic.apm.agent.hibernate.helper.HibernateHelper;
+
+import java.util.Collection;
+import java.util.Collections;
+
+public abstract class HibernateInstrumentation extends TracerAwareInstrumentation {
+
+    private static final Collection<String> HIBERNATE_GROUPS = Collections.singleton("hibernate");
+
+    protected static HibernateHelper hh = new HibernateHelper();
+
+    @Override
+    public final Collection<String> getInstrumentationGroupNames() {
+        return HIBERNATE_GROUPS;
+    }
+}

--- a/apm-agent-plugins/apm-hibernate-plugin/src/main/java/co/elastic/apm/agent/hibernate/SessionBuilderInstrumentation.java
+++ b/apm-agent-plugins/apm-hibernate-plugin/src/main/java/co/elastic/apm/agent/hibernate/SessionBuilderInstrumentation.java
@@ -1,0 +1,134 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2020 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
+package co.elastic.apm.agent.hibernate;
+
+import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
+import static net.bytebuddy.matcher.ElementMatchers.isInterface;
+import static net.bytebuddy.matcher.ElementMatchers.isPublic;
+import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.not;
+import static net.bytebuddy.matcher.ElementMatchers.returns;
+
+import javax.annotation.Nullable;
+
+import co.elastic.apm.agent.impl.ElasticApmTracer;
+import co.elastic.apm.agent.impl.transaction.AbstractSpan;
+import co.elastic.apm.agent.impl.transaction.Span;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.NamedElement;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import net.bytebuddy.matcher.ElementMatcher.Junction;
+
+import static co.elastic.apm.agent.hibernate.helper.HibernateHelper.*;
+
+/**
+ * Creates spans for Hibernate {@link SessionBuilder} execution
+ */
+public abstract class SessionBuilderInstrumentation extends HibernateInstrumentation {
+
+    private final ElementMatcher<? super MethodDescription> methodMatcher;
+
+    SessionBuilderInstrumentation(ElementMatcher<? super MethodDescription> methodMatcher) {
+        this.methodMatcher = methodMatcher;
+    }
+
+    @Override
+    public ElementMatcher<? super NamedElement> getTypeMatcherPreFilter() {
+        return nameStartsWith("org.hibernate");
+    }
+
+    @Override
+    public ElementMatcher<? super TypeDescription> getTypeMatcher() {
+    	
+    	Junction<TypeDescription> type = hasSuperType(named("org.hibernate.SessionBuilder"));
+        return not(isInterface()).and(type);
+    }
+
+    @Override
+    public ElementMatcher<? super MethodDescription> getMethodMatcher() {
+        return methodMatcher;
+    }
+    
+    /**
+     * Instruments:
+     * <ul>
+     *     <li?{@link org.hibernate.SessionBuilder#openSession()</li>
+     *     Gives more accurate details on open session.
+     *     after this method "Session openSession()" execution
+     *     Create a span for session open
+    
+     * </ul>
+     */
+    //@SuppressWarnings("DuplicatedCode")
+    public static class SessionOpenInstrumentation extends SessionBuilderInstrumentation {
+
+        public SessionOpenInstrumentation(ElasticApmTracer tracer) {
+            super(
+            		named("openSession")
+            			.and(returns(named("org.hibernate.Session")))
+            			.and(isPublic())
+            );
+        }
+
+
+        @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class, inline = false)
+        public static void onAfterExecute(@Advice.This Object sessionBuilder, 
+        								  @Advice.Origin("#m") String methodName,
+                                          @Advice.Thrown @Nullable Throwable t,
+                                          @Advice.Return Object session) {
+        	  
+        	String str = "After :"+methodName;
+        	AbstractSpan<?> parentSpan = tracer.getActive();
+        	hh.logMsg(str,"methodName="+methodName,"sessionBuilder="+sessionBuilder,"session="+session,
+        								"parentSpan="+parentSpan,"throwable="+t);
+        	if ( parentSpan == null ) return;
+        	
+        	Span span = tracer.getActiveSpan();
+        	hh.logMsg("tracer.getActiveSpan="+span);
+        	
+        	if( t != null ) {
+        		hh.logMsg("Exception capture error span={}",span);
+        		if( span != null)
+        		span.captureException(t).deactivate().end();
+        		return;
+        	}
+        	
+        	if( hh.isObjectAlreadyCreated(session) ) {
+        		hh.logMsg("Session already created so don't create span again.");
+        	}
+        	else {
+        		hh.createHibernateSpan(tracer.getActive(),
+        				HIB_SUB_TYPE+" "+HIB_SPANNAME_SESSION,//SPAN Name
+                		HIB_SPAN_TYPE,HIB_SUB_TYPE,HIB_SPAN_ACTION_CREATE,
+                		session,null,methodName);
+        	}
+        }
+
+    }
+   
+}

--- a/apm-agent-plugins/apm-hibernate-plugin/src/main/java/co/elastic/apm/agent/hibernate/SessionInstrumentation.java
+++ b/apm-agent-plugins/apm-hibernate-plugin/src/main/java/co/elastic/apm/agent/hibernate/SessionInstrumentation.java
@@ -1,0 +1,324 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2020 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
+package co.elastic.apm.agent.hibernate;
+
+import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
+import static net.bytebuddy.matcher.ElementMatchers.isInterface;
+import static net.bytebuddy.matcher.ElementMatchers.isPublic;
+import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.not;
+import static net.bytebuddy.matcher.ElementMatchers.returns;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import java.io.Serializable;
+import java.sql.Statement;
+
+import javax.annotation.Nullable;
+import javax.persistence.Entity;
+
+import org.hibernate.LockMode;
+import org.hibernate.LockOptions;
+import org.hibernate.Session;
+import org.hibernate.SharedSessionContract;
+import org.hibernate.Transaction;
+
+import co.elastic.apm.agent.impl.ElasticApmTracer;
+import co.elastic.apm.agent.impl.context.AbstractContext;
+import co.elastic.apm.agent.impl.transaction.AbstractSpan;
+import co.elastic.apm.agent.impl.transaction.Span;
+import co.elastic.apm.agent.impl.transaction.TraceContext;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.NamedElement;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import net.bytebuddy.matcher.ElementMatcher.Junction;
+
+/**
+ * Creates spans for Hibernate {@link SharedSessionContract} execution
+ */
+public abstract class SessionInstrumentation extends HibernateInstrumentation {
+
+    private final ElementMatcher<? super MethodDescription> methodMatcher;
+
+    SessionInstrumentation(ElementMatcher<? super MethodDescription> methodMatcher) {
+        this.methodMatcher = methodMatcher;
+    }
+
+    @Override
+    public ElementMatcher<? super NamedElement> getTypeMatcherPreFilter() {
+        return nameStartsWith("org.hibernate");
+    }
+
+    @Override
+    public ElementMatcher<? super TypeDescription> getTypeMatcher() {
+    	
+    	Junction<TypeDescription> supTypes = hasSuperType(named("org.hibernate.SharedSessionContract"));
+        return not(isInterface()).and(supTypes);
+    }
+
+    @Override
+    public ElementMatcher<? super MethodDescription> getMethodMatcher() {
+        return methodMatcher;
+    }
+	
+    /**
+     * Instruments:
+     * <ul>
+     *     <li>{@link Session#get(String, Serializable)} </li>
+     *     <li>{@link Session#get(String, Serializable, LockMode)} </li>
+     *     <li>{@link Session#get(String, Serializable, LockOptions)} </li>
+     * </ul>
+     */
+    //@SuppressWarnings("DuplicatedCode")
+    public static class ReadObjectsInstrumentation extends SessionInstrumentation {
+
+        public ReadObjectsInstrumentation(ElasticApmTracer tracer) {
+            super(
+                named("get")
+                	.and(takesArgument(0, String.class))
+                    .and(isPublic())
+            );
+        }
+
+        @Nullable
+        @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
+        public static Object onBeforeExecute(@Advice.This SharedSessionContract session, 
+        									 @Advice.Origin("#m") String methodName,
+                                             @Advice.Argument(0) String entityName) {
+
+            return hh.createHibernateSpan(tracer.getActive(),methodName+" "+entityName,
+            		hh.HIB_SPAN_TYPE,hh.HIB_SPAN_TYPE,hh.HIB_SPAN_ACTION_QUERY,//Use subtype for action as well.
+            		session,entityName,methodName);
+        }
+
+
+        @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class, inline = false)
+        public static void onAfterExecute(@Advice.This SharedSessionContract session,
+                                          @Advice.Enter @Nullable Object span,
+                                          @Advice.Thrown @Nullable Throwable t) {
+        	hh.logMsg("After Executing GET Method:", "session="+session,"Span="+span,
+        			"throwable"+t);
+            if (span == null) {
+                return;
+            }
+
+            ((Span) span).captureException(t)
+                .deactivate()
+                .end();
+        }
+    }
+    
+    /**
+     * Instruments: CUD(Create, Update, Delete) operations
+     * <ul>
+     *     <li>{@link Session#get(String, Serializable)} </li>
+     *     <li>{@link Session#get(String, Serializable, LockMode)} </li>
+     *     <li>{@link Session#get(String, Serializable, LockOptions)} </li>
+     *     
+     *     "save",
+                    "replicate",
+                    "saveOrUpdate",
+                    "update",
+                    "merge",
+                    "persist",
+                    "lock",
+                    "refresh",
+                    "insert",
+                    "delete",
+     * </ul>
+     */
+    //@SuppressWarnings("DuplicatedCode")
+    public static class CUDInstrumentation extends SessionInstrumentation {
+
+        public CUDInstrumentation(ElasticApmTracer tracer) {
+            super(
+                named("save").or(named("saveOrUpdate")).or(named("update"))
+                	.or(named("merge")).or(named("persist")).or(named("refresh"))
+                	.or(named("delete"))
+                	.and(takesArgument(0, Object.class))
+                    .and(isPublic())
+            );
+        }
+
+        @Nullable
+        @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
+        public static Object onBeforeExecute(@Advice.This Object session, @Advice.Origin("#m") String methodName,
+                                             @Advice.Argument(0) Object entityObject) {
+        	
+        	String entityName = entityObject.getClass().getSimpleName();
+        	return hh.createHibernateSpan(tracer.getActive(),methodName+" "+entityName,
+        			hh.HIB_SPAN_TYPE,hh.HIB_SPAN_TYPE,hh.HIB_SPAN_ACTION_QUERY,//Use subtype for action as well.
+            		session,entityObject,methodName);
+        }
+
+
+        @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class, inline = false)
+        public static void onAfterExecute(@Advice.This Object session,
+                                          @Advice.Enter @Nullable Object span,
+                                          @Advice.Thrown @Nullable Throwable t) {
+        	
+        	hh.logMsg("After Executing CUD methods:", "session="+session,"Span="+span,
+        								"throwable="+t);
+            if (span == null) {
+                return;
+            }
+
+            try {
+        		//Exception while closing the session
+        		if( t !=null ) ((Span) span).captureException(t);
+        	
+        	}finally {
+        		((Span) span).deactivate().end();
+        	}
+        }
+    }
+    
+    /**
+     * Instruments:
+     * <ul>
+     *     <li>{@link Session#beginTransaction())} </li>  
+     *     <li?{@link org.hibernate.SessionBuilder#openSession()</li>
+     *     Gives more accurate details on open session.
+     *     after this method "Session openSession()" execution
+     *     Create a span for session open
+    
+     * </ul>
+     */
+    //@SuppressWarnings("DuplicatedCode")
+    public static class SessionOpenInstrumentation extends SessionInstrumentation {
+
+        public SessionOpenInstrumentation(ElasticApmTracer tracer) {
+            super(
+            		named("beginTransaction").or(named("getTransaction"))
+            			.and(returns(named("org.hibernate.Transaction")))
+            			.and(isPublic())
+            );
+        }
+
+
+        @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class, inline = false)
+        public static void onAfterExecute(@Advice.This SharedSessionContract session, 
+        								  @Advice.Origin("#m") String methodName,
+                                          @Advice.Thrown @Nullable Throwable t,
+                                          @Advice.Return Transaction transaction) {
+        	  
+        	String str = "After :"+methodName;
+        	AbstractSpan<?> parentSpan = tracer.getActive();
+        	hh.logMsg(str,"methodName="+methodName,"session="+session,
+        								"transaction="+transaction,"parentSpan="+parentSpan,"throwable="+t);
+        	if ( parentSpan == null ) return;
+        	
+        	TraceContext tc = parentSpan.getTraceContext();
+        	AbstractContext absCtx = parentSpan.getContext();
+        	hh.logMsg(str,"TraceContext="+tc,"abstractContext="+absCtx);
+        	
+        	Span span = tracer.getActiveSpan();
+        	hh.logMsg("tracer.getActiveSpan="+span);
+        	
+        	if( t != null ) {
+        		hh.logMsg("Exception capture error span:");
+        		span.captureException(t).deactivate().end();
+        		return;
+        	}
+        	
+        	if( hh.isObjectAlreadyCreated(session) ) {
+        		hh.logMsg("Session already created so don't create span again.");
+        	}
+        	else {
+        		hh.createHibernateSpan(tracer.getActive(),
+        				hh.HIB_SPAN_TYPE+" "+hh.HIB_SPANNAME_SESSION,//SPAN Name
+                		hh.HIB_SPAN_TYPE,hh.HIB_SUB_TYPE,hh.HIB_SPAN_ACTION_CREATE,
+                		session,null,methodName);
+        	}
+        }
+    }
+    
+    /**
+     * Instruments:
+     * <ul>
+     *     <li>{@link Session#close())} </li>    
+    
+     * </ul>
+     */
+    //@SuppressWarnings("DuplicatedCode")
+    public static class SessionCloseInstrumentation extends SessionInstrumentation {
+
+        public SessionCloseInstrumentation(ElasticApmTracer tracer) {
+            super(
+                named("close").and(takesArguments(0))
+                    .and(isPublic())
+            );
+        }
+
+
+        @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class, inline = false)
+        public static void onSessionClose(@Advice.This SharedSessionContract session,
+                                         // @Advice.Enter @Nullable Object span,
+                                          @Advice.Thrown @Nullable Throwable t) {
+            
+        	AbstractSpan<?> parentSpan = tracer.getActive();
+        	hh.logMsg("onSessionClose:","parentSpan=",parentSpan,"session=",session,"throwable=",t);
+        	
+        	org.hibernate.internal.SessionImpl si = (org.hibernate.internal.SessionImpl)session;
+        	hh.logMsg("Session Identifier:",si.getSessionIdentifier().toString(),"Session IdentityHashcode:",System.identityHashCode(session));
+        	
+        	Span spanFromCache = hh.getSpanForObject(session);
+        	hh.logMsg("spanFromCache = {}",spanFromCache);
+        	if (  spanFromCache == null) {
+        		//No Span for this Session in the cache.
+        		// Close without session is not possible. Meaning it is duplicate call. 
+        		// Span is already close. should be ignored.
+        		hh.logMsg("Span might have already closed. No Action required.");
+        		return;
+        	}
+        	if (parentSpan == null) {
+                return;
+            }
+        	//Just for information.
+        	Span span = tracer.getActiveSpan();
+        	hh.logMsg("Current span {}",span);
+        	
+        	try {
+        		
+        		//Exception while closing the session
+        		if( t !=null ) {
+        			spanFromCache.captureException(t);
+        		}
+        	
+        	}finally {
+        		//Since Session is closed 
+        		//Remove it from the cache && DeActivate and End the span.
+        		hh.logMsg("Name of the span getting closed ",spanFromCache.toString());
+        		
+        		spanFromCache.deactivate().end();
+        		hh.removeObjectSpan(session);
+        	}
+
+        }
+    }
+}

--- a/apm-agent-plugins/apm-hibernate-plugin/src/main/java/co/elastic/apm/agent/hibernate/TransactionInstrumentation.java
+++ b/apm-agent-plugins/apm-hibernate-plugin/src/main/java/co/elastic/apm/agent/hibernate/TransactionInstrumentation.java
@@ -1,0 +1,163 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2020 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
+package co.elastic.apm.agent.hibernate;
+
+import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
+import static net.bytebuddy.matcher.ElementMatchers.isInterface;
+import static net.bytebuddy.matcher.ElementMatchers.isPublic;
+import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.not;
+import static net.bytebuddy.matcher.ElementMatchers.returns;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+import static net.bytebuddy.matcher.ElementMatchers.is;
+
+import java.io.Serializable;
+import java.sql.Statement;
+
+import javax.annotation.Nullable;
+import javax.persistence.Entity;
+
+import org.hibernate.LockMode;
+import org.hibernate.LockOptions;
+import org.hibernate.Session;
+import org.hibernate.SharedSessionContract;
+import org.hibernate.Transaction;
+import org.hibernate.resource.transaction.spi.TransactionStatus;
+
+import co.elastic.apm.agent.impl.ElasticApmTracer;
+import co.elastic.apm.agent.impl.context.AbstractContext;
+import co.elastic.apm.agent.impl.transaction.AbstractSpan;
+import co.elastic.apm.agent.impl.transaction.Span;
+import co.elastic.apm.agent.impl.transaction.TraceContext;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.NamedElement;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import net.bytebuddy.matcher.ElementMatcher.Junction;
+
+import static co.elastic.apm.agent.hibernate.helper.HibernateHelper.*;
+
+/**
+ * Creates spans for JDBC {@link Statement} execution
+ */
+public abstract class TransactionInstrumentation extends HibernateInstrumentation {
+	private final ElementMatcher<? super MethodDescription> methodMatcher;
+
+	TransactionInstrumentation(ElementMatcher<? super MethodDescription> methodMatcher) {
+		this.methodMatcher = methodMatcher;
+	}
+
+	@Override
+	public ElementMatcher<? super NamedElement> getTypeMatcherPreFilter() {
+		return nameStartsWith("org.hibernate");
+	}
+
+	@Override
+	public ElementMatcher<? super TypeDescription> getTypeMatcher() {
+		Junction<TypeDescription> type = hasSuperType(named("org.hibernate.Transaction"));
+		return not(isInterface()).and(type);
+	}
+
+	@Override
+	public ElementMatcher<? super MethodDescription> getMethodMatcher() {
+		return methodMatcher;
+	}
+
+	// @SuppressWarnings("DuplicatedCode")
+	public static class BeginInstrumentation extends TransactionInstrumentation {
+
+		public BeginInstrumentation(ElasticApmTracer tracer) {
+			super(named("begin").and(takesArguments(0)).and(isPublic()));
+		}
+
+		@Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class, inline = false)
+		public static void onAfterExecute(@Advice.This Object transaction, @Advice.Origin("#m") String methodName,
+				@Advice.Thrown @Nullable Throwable t) {
+
+			String str = "After :" + methodName;
+			AbstractSpan<?> parentSpan = tracer.getActive();
+			hh.logMsg(str, "methodName=" + methodName, "parentSpan=" + parentSpan, "throwable=" + t);
+			if (parentSpan == null)
+				return;
+			Span span = tracer.getActiveSpan();
+			hh.logMsg("tracer.getActiveSpan=" + span);
+			// if( span == null ) return;
+			if (t != null) {
+				hh.logMsg("Exception capture error span.");
+				if (span == null) {
+					parentSpan.captureException(t);
+					return;
+				}
+				span.captureException(t).deactivate().end();
+				return;
+			}
+
+			hh.createHibernateSpan(parentSpan, HIB_SUB_TYPE + " " + HIB_SPANNAME_TRANSACTION, // SPAN Name
+					HIB_SPAN_TYPE, HIB_SUB_TYPE, HIB_SPAN_ACTION_CREATE, null, null, methodName);
+		}
+	}
+
+	/**
+	 * Instruments:
+	 * <ul>
+	 * <li?{@link org.hibernate.SessionBuilder#openSession()</li> Gives more
+	 * accurate details on open session. after this method "Session openSession()"
+	 * execution Create a span for session open
+	 * 
+	 * </ul>
+	 */
+	// @SuppressWarnings("DuplicatedCode")
+	public static class CommitInstrumentation extends TransactionInstrumentation {
+
+		public CommitInstrumentation(ElasticApmTracer tracer) {
+			super(named("commit").and(takesArguments(0)).and(isPublic()));
+		}
+
+		@Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class, inline = false)
+		public static void onAfterExecute(@Advice.This Object transaction, @Advice.Origin("#m") String methodName,
+				@Advice.Thrown @Nullable Throwable t) {
+			hh.handleTransactionAfterExecute(transaction,methodName, tracer.getActive(), tracer.getActiveSpan(), t);
+		}
+	}
+
+	// @SuppressWarnings("DuplicatedCode")
+	// Not used this to be deleted.
+	public static class RollbackInstrumentation extends TransactionInstrumentation {
+
+		public RollbackInstrumentation(ElasticApmTracer tracer) {
+			super(named("rollback").and(takesArguments(0)).and(isPublic()));
+		}
+
+		@Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class, inline = false)
+		public static void onAfterExecute(@Advice.This Object transaction,@Advice.Origin("#m") String methodName,
+				@Advice.Thrown @Nullable Throwable t) {
+			hh.handleTransactionAfterExecute(transaction, methodName, tracer.getActive(), tracer.getActiveSpan(), t);
+		}
+	}
+
+}

--- a/apm-agent-plugins/apm-hibernate-plugin/src/main/java/co/elastic/apm/agent/hibernate/helper/HibernateGlobalState.java
+++ b/apm-agent-plugins/apm-hibernate-plugin/src/main/java/co/elastic/apm/agent/hibernate/helper/HibernateGlobalState.java
@@ -1,0 +1,43 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2020 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
+package co.elastic.apm.agent.hibernate.helper;
+
+import java.sql.Connection;
+
+import com.blogspot.mydailyjava.weaklockfree.WeakConcurrentMap;
+
+import co.elastic.apm.agent.impl.transaction.Span;
+import co.elastic.apm.agent.sdk.state.GlobalState;
+import co.elastic.apm.agent.sdk.weakmap.WeakMapSupplier;
+
+@GlobalState
+public class HibernateGlobalState {
+    public static final WeakConcurrentMap<Object, Span> objectSpanMap = WeakMapSupplier.createMap();
+
+    public static void clearInternalStorage() {
+        objectSpanMap.clear();
+    }
+
+}

--- a/apm-agent-plugins/apm-hibernate-plugin/src/main/java/co/elastic/apm/agent/hibernate/helper/HibernateHelper.java
+++ b/apm-agent-plugins/apm-hibernate-plugin/src/main/java/co/elastic/apm/agent/hibernate/helper/HibernateHelper.java
@@ -1,0 +1,190 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2020 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
+package co.elastic.apm.agent.hibernate.helper;
+
+import static co.elastic.apm.agent.hibernate.helper.HibernateGlobalState.objectSpanMap;
+
+import javax.annotation.Nullable;
+
+import org.hibernate.Transaction;
+import org.hibernate.resource.transaction.spi.TransactionStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import antlr.debug.Tracer;
+import co.elastic.apm.agent.impl.transaction.AbstractSpan;
+import co.elastic.apm.agent.impl.transaction.Span;
+
+public class HibernateHelper {
+
+	private static final Logger logger = LoggerFactory.getLogger(HibernateHelper.class);
+	public static final String HIB_SPAN_TYPE = "orm";
+	public static final String HIB_SUB_TYPE = "hibernate";
+	
+	public static final String HIB_SPAN_ACTION_CREATE = "create";
+	public static final String HIB_SPAN_ACTION_QUERY = "query";
+	public static final String HIB_SPAN_ACTION_LOAD = "load";
+	public static final String HIB_SPANNAME_ACTION_EXEC = "execute";
+	
+	public static final String HIB_SPANNAME_SESSION = "session";
+	public static final String HIB_SPANNAME_TRANSACTION = "transaction";
+	public static final String HIB_SPANNAME_ERROR = "error";
+	
+	
+	/**
+	 * Maps the provided Span with the session object.
+	 * @param obj
+	 * @param span
+	 * @param methodName
+	 */
+	public void mapObjectSpan(Object obj, Span span, String methodName) {
+		objectSpanMap.putIfAbsent(obj, span);
+	}
+	
+	/**
+	 * Returns the span associated to session
+	 * @param obj
+	 * @return
+	 */
+	public Span getSpanForObject(Object obj) {
+		return objectSpanMap.get(obj);
+	}
+	
+	/**
+	 * Removes Span for the session soon after the session closes.
+	 * @param obj
+	 * @return
+	 */
+	public Span removeObjectSpan(Object obj) {
+		return objectSpanMap.remove(obj);
+	}
+	
+	/**
+	 * To avoid duplicate sessions
+	 * @param obj
+	 * @return
+	 */
+	
+	public boolean isObjectAlreadyCreated(Object obj) {
+		return objectSpanMap.getIfPresent(obj) != null;
+	}
+
+	
+
+	public void logMsg(Object... objs) {
+		for (Object obj : objs) {
+			logger.debug("HIBERNATE: {}", obj);
+		}
+	}
+
+	/**
+	 * It creates a span 
+	 * @param parent
+	 * @param spanName
+	 * @param spanType
+	 * @param subType
+	 * @param action
+	 * @param object
+	 * @param entity
+	 * @param methodName
+	 * @return
+	 */
+	@Nullable
+	public Span createHibernateSpan(@Nullable AbstractSpan<?> parent, 
+			String spanName, String spanType, String subType, String action,
+			Object object, @Nullable Object entity, String methodName ) {
+		
+		String entityName = null;
+		if ( entity !=null )
+			entityName = (entity instanceof String) ? (String)entity :entity.getClass().getSimpleName();
+		
+		logMsg("Context Info:methodName,entityName, entity, session, parent.",
+				methodName,entityName, entity, object, parent);
+		
+		if ( parent == null ) {
+			logMsg("Null Parent Span...");
+			return null;
+		}
+		
+		Span span = parent.createSpan().activate();
+		span.withName(spanName,Span.PRIO_METHOD_SIGNATURE);
+		if (span.isSampled()) {
+			logMsg("Span is sampled:",span);
+			StringBuilder sn = span.getAndOverrideName(AbstractSpan.PRIO_DEFAULT);
+			logMsg("SpanName=" + sn);
+			
+		}
+		
+		span.withType(spanType);
+		span.withSubtype(subType);
+		span.withAction(action);
+
+		logMsg("SPAN=",span);
+		//So that It will not create a duplicate Span, even if this call again and again.
+		if( object != null)
+			mapObjectSpan(object, span, methodName);
+		return span;
+	}
+	
+	public boolean isItTransactionSpan(Span span) {
+		
+		String name = span.getNameAsString();
+		logMsg("SpanName is:",name);
+		if( name == null) return false;
+		return name.contains(HIB_SPANNAME_TRANSACTION);
+	}
+	
+	public void handleTransactionAfterExecute(Object transaction, String methodName,AbstractSpan<?> parentSpan, Span span, Throwable t) {
+		
+		String str = "After :" + methodName;
+		logMsg(str, "methodName=" + methodName, "parentSpan=" + parentSpan, "throwable=" + t);
+		if (parentSpan == null)
+			return;
+		logMsg("tracer.getActiveSpan=" + span);
+		
+		if (transaction instanceof org.hibernate.engine.transaction.internal.TransactionImpl) {
+			Transaction tr =  (org.hibernate.engine.transaction.internal.TransactionImpl)transaction;
+			TransactionStatus trStatus = tr.getStatus();
+			logMsg(trStatus);
+		}
+		
+		if (span == null) {// Should not happen this.
+			logMsg("Span shouldn't be null here");
+			return;
+		}
+		
+		
+		try {
+			if (t != null) {
+				logMsg("Exception capture error span={}", span);
+				span.captureException(t);
+			}
+		} finally {
+			if( isItTransactionSpan(span) )
+				span.deactivate().end();
+		}
+	}
+
+}

--- a/apm-agent-plugins/apm-hibernate-plugin/src/main/java/co/elastic/apm/agent/hibernate/helper/package-info.java
+++ b/apm-agent-plugins/apm-hibernate-plugin/src/main/java/co/elastic/apm/agent/hibernate/helper/package-info.java
@@ -1,0 +1,28 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2020 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
+@NonnullApi
+package co.elastic.apm.agent.hibernate.helper;
+
+import co.elastic.apm.agent.sdk.NonnullApi;

--- a/apm-agent-plugins/apm-hibernate-plugin/src/main/java/co/elastic/apm/agent/hibernate/package-info.java
+++ b/apm-agent-plugins/apm-hibernate-plugin/src/main/java/co/elastic/apm/agent/hibernate/package-info.java
@@ -1,0 +1,29 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2020 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
+
+@NonnullApi
+package co.elastic.apm.agent.hibernate;
+
+import co.elastic.apm.agent.sdk.NonnullApi;

--- a/apm-agent-plugins/apm-hibernate-plugin/src/main/resources/META-INF/services/co.elastic.apm.agent.sdk.ElasticApmInstrumentation
+++ b/apm-agent-plugins/apm-hibernate-plugin/src/main/resources/META-INF/services/co.elastic.apm.agent.sdk.ElasticApmInstrumentation
@@ -1,0 +1,7 @@
+co.elastic.apm.agent.hibernate.SessionInstrumentation$ReadObjectsInstrumentation
+co.elastic.apm.agent.hibernate.SessionInstrumentation$CUDInstrumentation
+co.elastic.apm.agent.hibernate.SessionInstrumentation$SessionCloseInstrumentation
+co.elastic.apm.agent.hibernate.SessionBuilderInstrumentation$SessionOpenInstrumentation
+co.elastic.apm.agent.hibernate.TransactionInstrumentation$BeginInstrumentation
+co.elastic.apm.agent.hibernate.TransactionInstrumentation$CommitInstrumentation
+co.elastic.apm.agent.hibernate.TransactionInstrumentation$RollbackInstrumentation

--- a/apm-agent-plugins/pom.xml
+++ b/apm-agent-plugins/pom.xml
@@ -20,6 +20,7 @@
     <modules>
         <module>apm-jaxrs-plugin</module>
         <module>apm-jdbc-plugin</module>
+        <module>apm-hibernate-plugin</module>
         <module>apm-jsf-plugin</module>
         <module>apm-opentracing-plugin</module>
         <module>apm-servlet-plugin</module>

--- a/elastic-apm-agent/pom.xml
+++ b/elastic-apm-agent/pom.xml
@@ -240,6 +240,12 @@
             <artifactId>apm-scala-concurrent-plugin</artifactId>
             <version>${project.version}</version>
         </dependency>
+        
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>apm-hibernate-plugin</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <!-- For auto-generating configuration docs -->
         <dependency>


### PR DESCRIPTION
## What does this PR do?
Supports tracing for Hibernate services calls for Session - Open/Close, Transaction - Open/Close, All CRUD Operations.
- It primarily captures method names and the object being handled.  Ultimately all the calls will land in JDBC layer and tracing in that layer is taken care by another plugin.

Instruments below mentioned Hibernate Services calls.

- co.elastic.apm.agent.hibernate.SessionBuilderInstrumentation$SessionOpenInstrumentation
- co.elastic.apm.agent.hibernate.SessionInstrumentation$SessionCloseInstrumentation
- co.elastic.apm.agent.hibernate.TransactionInstrumentation$BeginInstrumentation
- co.elastic.apm.agent.hibernate.TransactionInstrumentation$CommitInstrumentation
- co.elastic.apm.agent.hibernate.TransactionInstrumentation$RollbackInstrumentation
- co.elastic.apm.agent.hibernate.SessionInstrumentation$ReadObjectsInstrumentation
- co.elastic.apm.agent.hibernate.SessionInstrumentation$CUDInstrumentation

## Checklist
This is a new plugin for Hibernate support.  
 
